### PR TITLE
Added zero padding when 10 or more files parts are needed

### DIFF
--- a/split-file.js
+++ b/split-file.js
@@ -173,7 +173,11 @@ function splitFile(file, partInfo, callback) {
         });
 
         // Part name (file name of part)
-        var partName = file + ".sf-part" + info.number;
+        var str = "" + info.number;
+        var pad = "000";
+        var partNumber = pad.substring(0, pad.length - str.length) + str;
+
+        var partName = file + ".sf-part" + partNumber;
         partFiles.push(partName);
 
         // Open up writer

--- a/split-file.js
+++ b/split-file.js
@@ -173,11 +173,24 @@ function splitFile(file, partInfo, callback) {
         });
 
         // Part name (file name of part)
-        var str = "" + info.number;
-        var pad = "000";
-        var partNumber = pad.substring(0, pad.length - str.length) + str;
-
-        var partName = file + ".sf-part" + partNumber;
+        // get the max number of digits to generate for part number
+        // ex. if original file is split into 4 files, then it will be 1
+        // ex. if original file is split into 14 files, then it will be 2
+        // etc.
+        var maxPaddingCount = String(partInfo.length).length;
+        // initial part number
+        // ex. '0', '00', '000', etc.
+        var currentPad = '';
+        for (var i = 0; i < maxPaddingCount; i++) {
+          currentPad += '0';
+        }
+        // construct part number for current file part
+        // <file>.sf-part01
+        // ...
+        // <file>.sf-part14
+        var unpaddedPartNumber = '' + info.number;
+        var partNumber = currentPad.substring(0, currentPad.length - unpaddedPartNumber.length) + unpaddedPartNumber;
+        var partName = file + '.sf-part' + partNumber;
         partFiles.push(partName);
 
         // Open up writer


### PR DESCRIPTION
I use this tool for splitting files and concatenating them later using `cat *sf-part* > bundle.tar.gz`. However, I ran into an issue when there are more than 10 parts. The reason is that `cat` sorts things in alphabetical order so given 10 files, `cat *sf-part* > bundle.tar.gz` would merge in this order:
```
file.sf-part1
file.sf-part10
file.sf-part2
file.sf-part3
...
```
and would result in an corrupt bundle.

To fix this, I made it so that the resulting file part names are padded with `0` as needed. So 14 parts would result the file part names to end in `<file>.sf-part01, <file>.sf-part02, <file>.sf-part03, ... <file>.sf-part14`