### PR TITLE
Fix CLI

### DIFF
--- a/split-file-cli.js
+++ b/split-file-cli.js
@@ -19,6 +19,7 @@ Cli.prototype.parse = function (option) {
       break;
     case '-x':
       this.method = this.splitFileBySize
+      break;
     default:
       this.method = this.help;
   }


### PR DESCRIPTION
Someone forgot a `break;` for the switch case `-x` so it went to the default option, which just showed the help menu.